### PR TITLE
Skip the remainder of parsing once a field is determined as unexported

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -122,6 +122,9 @@ func parseFields(v reflect.Value) (Fields, error) {
 			return nil, err
 		}
 		f.CanSet = v.Field(i).CanSet()
+		if !f.CanSet {
+			continue
+		}
 		f.Index = i
 		tag := parseStrucTag(field.Tag)
 		if tag.Sizeof != "" {


### PR DESCRIPTION
Otherwise fields that won't be packed anyway can cause the parser to
bail with an error