### PR TITLE
fix go vet issue

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -38,7 +38,7 @@ func TestSizeOffTypes(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2,
 	}
 	if !bytes.Equal(reference, buf.Bytes()) {
-		t.Errorf("reference != bytes: %v", reference, buf.Bytes())
+		t.Errorf("reference: %v != bytes: %v", reference, buf.Bytes())
 	}
 	reader := bytes.NewReader(buf.Bytes())
 	for _, b := range bits {


### PR DESCRIPTION
Prior to this commit, the test cases were failing on Go 1.10,
as the latest version of Go enables go vet by default when
running go test.

    ./types_test.go:41: Errorf call needs 1 arg but has 2 args
    FAIL	github.com/lunixbochs/struc [build failed]