### PR TITLE
struc: support Custom slice types

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -161,7 +161,7 @@ func parseFieldsLocked(v reflect.Value) (Fields, error) {
 			}
 			f.Sizefrom = source.Index
 		}
-		if f.Len == -1 && f.Sizefrom == nil {
+		if f.Len == -1 && f.Sizefrom == nil && f.Type != CustomType {
 			return nil, fmt.Errorf("struc: field `%s` is a slice with no length or sizeof field", field.Name)
 		}
 		// recurse into nested structs


### PR DESCRIPTION
Useful for implementing e.g. NULL-terminated slices
whose length is unknown and cannot be determined by
a field in the struct.