### PR TITLE
Support packing/unpacking of custom slices, adds tests

### DIFF
--- a/custom_test.go
+++ b/custom_test.go
@@ -199,7 +199,9 @@ func TestCustomTypes(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
+		// TODO: Switch to t.Run() when Go 1.7 is the minimum supported version.
+		t.Log("RUN ", test.name)
+		runner := func(t *testing.T) {
 			defer func() {
 				if r := recover(); r == nil {
 					if test.expectPanic {
@@ -220,6 +222,7 @@ func TestCustomTypes(t *testing.T) {
 			if !reflect.DeepEqual(test.packObj, test.emptyObj) {
 				t.Fatal("error unpacking, expect:", test.packObj, "found:", test.emptyObj)
 			}
-		})
+		}
+		runner(t)
 	}
 }

--- a/custom_test.go
+++ b/custom_test.go
@@ -72,21 +72,26 @@ func TestCustomStruct(t *testing.T) {
 }
 
 // TODO: slices of custom types don't work yet
-/*
-type Int3SliceStruct struct {
+type ArrayInt3Struct struct {
 	I [2]Int3
 }
 
-func TestCustomSliceStruct(t *testing.T) {
+func TestArrayOfCustomStructPanic(t *testing.T) {
+	// Expect panic.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("did not panic")
+		}
+	}()
 	var buf bytes.Buffer
-	i := Int3SliceStruct{[2]Int3{3, 4}}
+	i := ArrayInt3Struct{[2]Int3{3, 4}}
 	if err := Pack(&buf, &i); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(buf.Bytes(), []byte{0, 0, 3}) {
 		t.Fatal("error packing custom int struct")
 	}
-	var i2 Int3SliceStruct
+	var i2 ArrayInt3Struct
 	if err := Unpack(&buf, &i2); err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +99,6 @@ func TestCustomSliceStruct(t *testing.T) {
 		t.Fatal("error unpacking custom int struct")
 	}
 }
-*/
 
 // Slice of uint8, stored in a zero terminated list.
 type IntSlice []uint8

--- a/parse.go
+++ b/parse.go
@@ -78,22 +78,30 @@ func parseField(f reflect.StructField) (fd *Field, tag *strucTag, err error) {
 		fd.Ptr = true
 		fd.kind = f.Type.Elem().Kind()
 	}
-	// check for custom types
+	// Custom types containing slices handle their own elem processing, but
+	// slices of a custom type do not.
+	//
+	//    type IntSlice []int
+	//    type MyInt int
+	//    type Fields struct {
+	//        intsA IntSlice // Handles own element process
+	//        intsB []MyInt  // Doesn't handle own element processing
+	//    }
+
+	// Disallow slice of custom struct
+	if fd.Slice || fd.Array {
+		abstract := reflect.TypeOf((*Custom)(nil)).Elem()
+		if reflect.PtrTo(f.Type.Elem()).Implements(abstract) {
+			// TODO:  slices/arrays of custom types don't work yet
+			panic(fmt.Sprint("slice of custom struct is not supported:", f.Type.String()))
+		}
+	}
+	// Check custom types, allow custom struct containing a slice/array to process
+	// their own elements.
 	tmp := reflect.New(f.Type)
 	if _, ok := tmp.Interface().(Custom); ok {
-		// Custom types containing slices handle their own elem processing, but
-		// slices of a custom type do not.
-		//
-		//    type IntSlice []int
-		//    type MyInt int
-		//    type Fields struct {
-		//        intsA IntSlice // Handles own, fd.Slice = false
-		//        intsB []MyInt  // Doesn't handle own, fd.Slice = true
-		//    }
-		// FIXME: Is there a better way than string processing to determine this?
-		if tmp.String()[:2] != "[]" {
-			fd.Slice = false
-		}
+		fd.Slice = false
+		fd.Array = false
 		fd.Type = CustomType
 		return
 	}

--- a/parse.go
+++ b/parse.go
@@ -93,7 +93,7 @@ func parseField(f reflect.StructField) (fd *Field, tag *strucTag, err error) {
 		abstract := reflect.TypeOf((*Custom)(nil)).Elem()
 		if reflect.PtrTo(f.Type.Elem()).Implements(abstract) {
 			// TODO:  slices/arrays of custom types don't work yet
-			panic(fmt.Sprint("slice of custom struct is not supported:", f.Type.String()))
+			panic(fmt.Sprint("array/slice of custom struct is not supported: ", f.Type.String()))
 		}
 	}
 	// Check custom types, allow custom struct containing a slice/array to process

--- a/struc.go
+++ b/struc.go
@@ -42,6 +42,19 @@ func prep(data interface{}) (reflect.Value, Packer, error) {
 	case reflect.Struct:
 		fields, err := parseFields(value)
 		return value, fields, err
+	case reflect.Array:
+		panic("pack of array is not supported")
+	case reflect.Ptr:
+		// Only pointer to custom type of slice/array of types is supported.
+		if _, ok := value.Interface().(Custom); !ok {
+			if value.Elem().Kind() == reflect.Array {
+				panic("pack of array pointer is not supported")
+			}
+			if value.Elem().Kind() == reflect.Slice {
+				panic("pack of slice pointer is not supported")
+			}
+		}
+		fallthrough
 	default:
 		if !value.IsValid() {
 			return reflect.Value{}, nil, fmt.Errorf("Invalid reflect.Value for %+v", data)


### PR DESCRIPTION
Allows custom types containing slices to handle their own elem
processing. Does not affect slices of a custom type.

Useful for implementing e.g. NULL-terminated slices whose length
is unknown and cannot be determined by a field in the struct.

    type IntSlice []int
    type MyInt int
    type Fields struct {
        intsA IntSlice // Handles own, fd.Slice = false
        intsB []MyInt  // Doesn't handle own, fd.Slice = true
    }

This is one method to inform the parsing process of the different
requirements. I'm not sure it is ideal. Another option is new
method, such as `HandlesElements()` on the Custom interface.

Closes #60