### PR TITLE
fixed race in Pack() on default options initialization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 script: go test -v
 
 go:
-  - 1.2
   - 1.3
   - 1.4
+  - 1.13
   - tip

--- a/struc.go
+++ b/struc.go
@@ -13,9 +13,11 @@ type Options struct {
 	Order     binary.ByteOrder
 }
 
+const defaultPtrSize = 32
+
 func (o *Options) Validate() error {
 	if o.PtrSize == 0 {
-		o.PtrSize = 32
+		o.PtrSize = defaultPtrSize
 	} else {
 		switch o.PtrSize {
 		case 8, 16, 32, 64:
@@ -26,7 +28,9 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-var emptyOptions = &Options{}
+var emptyOptions = &Options{
+	PtrSize: defaultPtrSize,
+}
 
 func prep(data interface{}) (reflect.Value, Packer, error) {
 	value := reflect.ValueOf(data)

--- a/struc.go
+++ b/struc.go
@@ -13,11 +13,9 @@ type Options struct {
 	Order     binary.ByteOrder
 }
 
-const defaultPtrSize = 32
-
 func (o *Options) Validate() error {
 	if o.PtrSize == 0 {
-		o.PtrSize = defaultPtrSize
+		o.PtrSize = 32
 	} else {
 		switch o.PtrSize {
 		case 8, 16, 32, 64:
@@ -28,8 +26,11 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-var emptyOptions = &Options{
-	PtrSize: defaultPtrSize,
+var emptyOptions = &Options{}
+
+func init() {
+	// fill default values to avoid data race to be reported by race detector.
+	emptyOptions.Validate()
 }
 
 func prep(data interface{}) (reflect.Value, Packer, error) {

--- a/test_pack_init/doc.go
+++ b/test_pack_init/doc.go
@@ -1,3 +1,4 @@
 package test_pack_init
 
-// This is a placeholder package for a test on specific race condition.
+// This is a placeholder package for a test on specific race detector report on
+// default Options initialization.

--- a/test_pack_init/doc.go
+++ b/test_pack_init/doc.go
@@ -1,0 +1,3 @@
+package test_pack_init
+
+// This is a placeholder package for a test on specific race condition.

--- a/test_pack_init/pack_init_test.go
+++ b/test_pack_init/pack_init_test.go
@@ -1,0 +1,29 @@
+package test_pack_init
+
+import (
+	"bytes"
+	"github.com/lunixbochs/struc"
+	"sync"
+	"testing"
+)
+
+type Example struct {
+	I int `struc:int`
+}
+
+// TestParallelPack checks whether Pack is goroutine-safe. Run it with -race flag.
+// Keep it as a single test in package since it is likely to be triggered on racy initialization
+// of global objects.
+func TestParallelPack(t *testing.T) {
+	var wg sync.WaitGroup
+	val := Example{}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			_ = struc.Pack(&buf, &val)
+		}()
+	}
+	wg.Wait()
+}

--- a/test_pack_init/pack_init_test.go
+++ b/test_pack_init/pack_init_test.go
@@ -12,8 +12,8 @@ type Example struct {
 }
 
 // TestParallelPack checks whether Pack is goroutine-safe. Run it with -race flag.
-// Keep it as a single test in package since it is likely to be triggered on racy initialization
-// of global objects.
+// Keep it as a single test in package since it is likely to be triggered on initialization
+// of global objects reported as a data race by race detector.
 func TestParallelPack(t *testing.T) {
 	var wg sync.WaitGroup
 	val := Example{}


### PR DESCRIPTION
Default Options used in Pack() is a global object with zero-initialized
fields. Validate() changes PtrSize field value on the first call
from zero to 32. It is a data race if multiple goroutines call Pack().

This commit fixes this issue and adds a tests its correctnes. Important
note about test is that it should be in a separate package because
it needs to be run exclusively so that it is guaranteed that it is run
first to catch this race condition.