### PR TITLE
Fix arrayField unpack segfault

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -14,6 +14,44 @@ type BenchExample struct {
 	Length  int32
 }
 
+func BenchmarkArrayEncode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := Pack(&buf, arrayReference); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSliceEncode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := Pack(&buf, sliceReference); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkArrayDecode(b *testing.B) {
+	var out ExampleArray
+	for i := 0; i < b.N; i++ {
+		buf := bytes.NewBuffer(arraySliceReferenceBytes)
+		if err := Unpack(buf, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSliceDecode(b *testing.B) {
+	var out ExampleSlice
+	for i := 0; i < b.N; i++ {
+		buf := bytes.NewBuffer(arraySliceReferenceBytes)
+		if err := Unpack(buf, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 type BenchStrucExample struct {
 	Test    [5]byte `struc:"[5]byte"`
 	A       int     `struc:"int32"`

--- a/fields.go
+++ b/fields.go
@@ -122,7 +122,12 @@ func (f Fields) Unpack(r io.Reader, val reflect.Value, options *Options) error {
 		}
 		if field.Type == Struct {
 			if field.Slice {
-				vals := reflect.MakeSlice(v.Type(), length, length)
+				var vals reflect.Value
+				if field.Array {
+					vals = reflect.Zero(reflect.ArrayOf(length, v.Type().Elem()))
+				} else {
+					vals = reflect.MakeSlice(v.Type(), length, length)
+				}
 				for i := 0; i < length; i++ {
 					v := vals.Index(i)
 					fields, err := parseFields(v)

--- a/fields_test.go
+++ b/fields_test.go
@@ -57,3 +57,25 @@ func TestFieldsSizefromBad(t *testing.T) {
 	}()
 	Pack(&buf, &test)
 }
+
+type StructWithinArray struct {
+	a uint32
+}
+
+type StructHavingArray struct {
+	Props [1]StructWithinArray `struc:"[1]StructWithinArray"`
+}
+
+func TestStrucArray(t *testing.T) {
+	var buf bytes.Buffer
+	a := &StructHavingArray{[1]StructWithinArray{}}
+	err := Pack(&buf, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := &StructHavingArray{}
+	err = Unpack(&buf, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/struc_test.go
+++ b/struc_test.go
@@ -76,6 +76,85 @@ type Example struct {
 
 var five = 5
 
+type ExampleStructWithin struct {
+	a uint8
+}
+
+type ExampleSlice struct {
+	PropsLen uint8 `struc:"sizeof=Props"`
+	Props    []ExampleStructWithin
+}
+
+type ExampleArray struct {
+	PropsLen uint8
+	Props    [16]ExampleStructWithin `struc:"[16]ExampleStructWithin"`
+}
+
+var arraySliceReferenceBytes = []byte{
+	16,
+	0, 0, 0, 1,
+	0, 0, 0, 1,
+	0, 0, 0, 2,
+	0, 0, 0, 3,
+	0, 0, 0, 4,
+	0, 0, 0, 5,
+	0, 0, 0, 6,
+	0, 0, 0, 7,
+	0, 0, 0, 8,
+	0, 0, 0, 9,
+	0, 0, 0, 10,
+	0, 0, 0, 11,
+	0, 0, 0, 12,
+	0, 0, 0, 13,
+	0, 0, 0, 14,
+	0, 0, 0, 15,
+	0, 0, 0, 16,
+}
+
+var arrayReference = &ExampleArray{
+	16,
+	[16]ExampleStructWithin{
+		ExampleStructWithin{1},
+		ExampleStructWithin{2},
+		ExampleStructWithin{3},
+		ExampleStructWithin{4},
+		ExampleStructWithin{5},
+		ExampleStructWithin{6},
+		ExampleStructWithin{7},
+		ExampleStructWithin{8},
+		ExampleStructWithin{9},
+		ExampleStructWithin{10},
+		ExampleStructWithin{11},
+		ExampleStructWithin{12},
+		ExampleStructWithin{13},
+		ExampleStructWithin{14},
+		ExampleStructWithin{15},
+		ExampleStructWithin{16},
+	},
+}
+
+var sliceReference = &ExampleSlice{
+	16,
+	[]ExampleStructWithin{
+		ExampleStructWithin{1},
+		ExampleStructWithin{2},
+		ExampleStructWithin{3},
+		ExampleStructWithin{4},
+		ExampleStructWithin{5},
+		ExampleStructWithin{6},
+		ExampleStructWithin{7},
+		ExampleStructWithin{8},
+		ExampleStructWithin{9},
+		ExampleStructWithin{10},
+		ExampleStructWithin{11},
+		ExampleStructWithin{12},
+		ExampleStructWithin{13},
+		ExampleStructWithin{14},
+		ExampleStructWithin{15},
+		ExampleStructWithin{16},
+	},
+}
+
 var reference = &Example{
 	nil,
 	1, 2, 3, 4, 5, 6, 7, 8, 0, []byte{'a', 'b', 'c', 'd'},


### PR DESCRIPTION
The following snippet generates a segfault.
I made this fix proposal & added the corresponding test.

Feel free to comment :)

````golang
package main

import (
    "bytes"
    "fmt"
    "github.com/lunixbochs/struc"
)

// FibPath represents VPP binary API type 'fib_path'.
type SomeStruct struct {
	a  uint32
}

type Example struct {
	ExampleProps      [1]SomeStruct `struc:"[1]SomeStruct"`
}

func main() {
    fmt.Printf("Hello\n")
    var buf bytes.Buffer
    t := &Example{[1]SomeStruct{}}
    _ = struc.Pack(&buf, t)
    o := &Example{}
    _ = struc.Unpack(&buf, o)
}
````
````
panic: reflect.MakeSlice of non-slice type
...
github.com/lunixbochs/struc.Fields.Unpack(0xc0000a00c0, 0x1, 0x1, 0x1193f80, 0xc000092b10, 0x113e6e0, 0xc0000a75b4, 0x199, 0x127afa0, 0x127bbe0, ...)
        /Users/.../struc/fields.go:125 +0x1cf
github.com/lunixbochs/struc.UnpackWithOptions(0x1193f80, 0xc000092b10, 0x1127e20, 0xc0000a75b4, 0x127afa0, 0x0, 0x0)
        /Users/.../struc/struc.go:103 +0xe1
github.com/lunixbochs/struc.Unpack(...)
        /Users/.../struc/struc.go:89
github.com/lunixbochs/struc.TestStrucArray(0xc0000dec60)
        /Users/.../struc/fields_test.go:77 +0x122
````


Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>